### PR TITLE
Add support for optionals, variable annotations, and interfaces

### DIFF
--- a/Syntaxes/Teal.plist
+++ b/Syntaxes/Teal.plist
@@ -332,6 +332,10 @@
           </dict>
           <dict>
             <key>include</key>
+            <string>#interface-block</string>
+          </dict>
+          <dict>
+            <key>include</key>
             <string>#record-block</string>
           </dict>
           <dict>
@@ -691,6 +695,43 @@
           </dict>
         </array>
       </dict>
+      <key>extendable-type</key>
+      <dict>
+        <key>patterns</key>
+        <array>
+          <dict>
+            <key>begin</key>
+            <string>(\bis\b)\s*(&lt;\s*)?([a-zA-Z_][a-zA-Z0-9_, ]*\s*)?(&gt;\s*)?</string>
+            <key>end</key>
+            <string>(\bwhere\b)</string>
+            <key>beginCaptures</key>
+            <dict>
+              <key>1</key>
+              <dict>
+                <key>name</key>
+                <string>keyword.control.is.teal</string>
+              </dict>
+              <key>3</key>
+              <dict>
+                <key>name</key>
+                <string>entity.other.inherited-class.teal</string>
+              </dict>
+            </dict>
+            <key>endCaptures</key>
+            <dict>
+              <key>1</key>
+              <dict>
+                <key>name</key>
+                <string>keyword.control.where.teal</string>
+              </dict>
+            </dict>
+          </dict>
+          <dict>
+            <key>include</key>
+            <string>#type</string>
+          </dict>
+        </array>
+      </dict>
       <key>function-type</key>
       <dict>
         <key>patterns</key>
@@ -968,6 +1009,97 @@
           </dict>
         </array>
       </dict>
+      <key>interface-block</key>
+      <dict>
+        <key>begin</key>
+        <string>(\binterface\b)</string>
+        <key>end</key>
+        <string>(\bend\b)</string>
+        <key>beginCaptures</key>
+        <dict>
+          <key>0</key>
+          <dict>
+            <key>name</key>
+            <string>storage.type.interface.teal</string>
+          </dict>
+        </dict>
+        <key>endCaptures</key>
+        <dict>
+          <key>0</key>
+          <dict>
+            <key>name</key>
+            <string>keyword.control.teal</string>
+          </dict>
+        </dict>
+        <key>name</key>
+        <string>statement.interface-block.teal</string>
+        <key>patterns</key>
+        <array>
+          <dict>
+            <key>include</key>
+            <string>#extendable-type</string>
+          </dict>
+          <dict>
+            <key>include</key>
+            <string>#comment</string>
+          </dict>
+          <dict>
+            <key>include</key>
+            <string>#enum-block</string>
+          </dict>
+          <dict>
+            <key>include</key>
+            <string>#record-block</string>
+          </dict>
+          <dict>
+            <key>include</key>
+            <string>#new-type-declaration</string>
+          </dict>
+          <dict>
+            <key>match</key>
+            <string>^\s*\buserdata\b</string>
+            <key>name</key>
+            <string>storage.type.userdata.teal</string>
+          </dict>
+          <dict>
+            <key>begin</key>
+            <string>^\s*\bmetamethod\b</string>
+            <key>end</key>
+            <string>:</string>
+            <key>beginCaptures</key>
+            <dict>
+              <key>0</key>
+              <dict>
+                <key>name</key>
+                <string>storage.type.metamethod.teal</string>
+              </dict>
+            </dict>
+            <key>patterns</key>
+            <array>
+              <dict>
+                <key>include</key>
+                <string>#function-name</string>
+              </dict>
+            </array>
+          </dict>
+          <dict>
+            <key>match</key>
+            <string>^\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*:</string>
+            <key>captures</key>
+            <dict>
+              <key>1</key>
+              <dict>
+                <key>name</key>
+                <string>variable.other.teal</string>
+              </dict>
+            </dict>
+          </dict>
+          <dict>
+            <key>include</key>
+            <string>#type</string>
+          </dict>
+        </array>
+      </dict>
       <key>record-block</key>
       <dict>
         <key>begin</key>
@@ -994,6 +1126,10 @@
         <string>statement.record-block.teal</string>
         <key>patterns</key>
         <array>
+          <dict>
+            <key>include</key>
+            <string>#extendable-type</string>
+          </dict>
           <dict>
             <key>include</key>
             <string>#comment</string>

--- a/Syntaxes/Teal.plist
+++ b/Syntaxes/Teal.plist
@@ -35,6 +35,10 @@
           </dict>
           <dict>
             <key>include</key>
+            <string>#variable-annotation</string>
+          </dict>
+          <dict>
+            <key>include</key>
             <string>#constant</string>
           </dict>
           <dict>
@@ -1536,6 +1540,13 @@
         <string>\b(local|global)\b</string>
         <key>name</key>
         <string>storage.modifier.teal</string>
+      </dict>
+      <key>variable-annotation</key>
+      <dict>
+        <key>match</key>
+        <string>\&lt;\b(const|close|total)\b\&gt;</string>
+        <key>name</key>
+        <string>storage.modifier.annotation.teal</string>
       </dict>
       <key>type-annotation</key>
       <dict>

--- a/Syntaxes/Teal.plist
+++ b/Syntaxes/Teal.plist
@@ -716,14 +716,12 @@
                 <string>#comment</string>
               </dict>
               <dict>
-                <key>match</key>
-                <string>[a-zA-Z_][a-zA-Z0-9_]*\s*(?=:)</string>
-                <key>name</key>
-                <string>function.argument.teal</string>
+                <key>include</key>
+                <string>#function-arg-name</string>
               </dict>
               <dict>
                 <key>include</key>
-                <string>#optional</string>
+                <string>#function-arg-type</string>
               </dict>
               <dict>
                 <key>include</key>

--- a/Syntaxes/Teal.plist
+++ b/Syntaxes/Teal.plist
@@ -107,6 +107,18 @@
           </dict>
         </array>
       </dict>
+      <key>optional</key>
+      <dict>
+        <key>patterns</key>
+        <array>
+          <dict>
+            <key>name</key>
+            <string>storage.modifier.optional.teal</string>
+            <key>match</key>
+            <string>(\?)</string>
+          </dict>
+        </array>
+      </dict>
       <key>constant</key>
       <dict>
         <key>patterns</key>
@@ -422,15 +434,23 @@
         <array>
           <dict>
             <key>begin</key>
-            <string>\bfunction\b</string>
+            <string>(\bfunction\b)</string>
             <key>end</key>
-            <string>\bend\b</string>
-            <key>captures</key>
+            <string>(\bend\b)</string>
+            <key>beginCaptures</key>
             <dict>
               <key>0</key>
               <dict>
                 <key>name</key>
                 <string>keyword.declaration.function.teal</string>
+              </dict>
+            </dict>
+            <key>endCaptures</key>
+            <dict>
+              <key>0</key>
+              <dict>
+                <key>name</key>
+                <string>keyword.control.teal</string>
               </dict>
             </dict>
             <key>patterns</key>
@@ -593,6 +613,10 @@
                 <key>include</key>
                 <string>#comment</string>
               </dict>
+              <dict>
+                <key>include</key>
+                <string>#optional</string>
+              </dict>
             </array>
           </dict>
           <dict>
@@ -609,6 +633,10 @@
               <dict>
                 <key>include</key>
                 <string>#comment</string>
+              </dict>
+              <dict>
+                <key>include</key>
+                <string>#optional</string>
               </dict>
             </array>
           </dict>
@@ -692,6 +720,10 @@
                 <string>[a-zA-Z_][a-zA-Z0-9_]*\s*(?=:)</string>
                 <key>name</key>
                 <string>function.argument.teal</string>
+              </dict>
+              <dict>
+                <key>include</key>
+                <string>#optional</string>
               </dict>
               <dict>
                 <key>include</key>
@@ -937,15 +969,23 @@
       <key>record-block</key>
       <dict>
         <key>begin</key>
-        <string>\brecord\b</string>
+        <string>(\brecord\b)</string>
         <key>end</key>
-        <string>\bend\b</string>
-        <key>captures</key>
+        <string>(\bend\b)</string>
+        <key>beginCaptures</key>
         <dict>
           <key>0</key>
           <dict>
             <key>name</key>
             <string>storage.type.record.teal</string>
+          </dict>
+        </dict>
+        <key>endCaptures</key>
+        <dict>
+          <key>0</key>
+          <dict>
+            <key>name</key>
+            <string>keyword.control.teal</string>
           </dict>
         </dict>
         <key>name</key>
@@ -1080,15 +1120,23 @@
       <key>enum-block</key>
       <dict>
         <key>begin</key>
-        <string>\benum\b</string>
+        <string>(\benum\b)</string>
         <key>end</key>
-        <string>\bend\b</string>
-        <key>captures</key>
+        <string>(\bend\b)</string>
+        <key>beginCaptures</key>
         <dict>
           <key>0</key>
           <dict>
             <key>name</key>
             <string>storage.type.enum.teal</string>
+          </dict>
+        </dict>
+        <key>endCaptures</key>
+        <dict>
+          <key>0</key>
+          <dict>
+            <key>name</key>
+            <string>keyword.control.teal</string>
           </dict>
         </dict>
         <key>patterns</key>
@@ -1184,10 +1232,18 @@
       <key>if-block</key>
       <dict>
         <key>begin</key>
-        <string>\bif\b</string>
+        <string>(\bif\b)</string>
         <key>end</key>
-        <string>\bend\b</string>
-        <key>captures</key>
+        <string>(\bend\b)</string>
+        <key>beginCaptures</key>
+        <dict>
+          <key>0</key>
+          <dict>
+            <key>name</key>
+            <string>keyword.control.if.teal</string>
+          </dict>
+        </dict>
+        <key>endCaptures</key>
         <dict>
           <key>0</key>
           <dict>
@@ -1211,15 +1267,23 @@
           </dict>
           <dict>
             <key>begin</key>
-            <string>\belseif\b</string>
+            <string>(\belseif\b)</string>
             <key>end</key>
-            <string>\bthen\b</string>
-            <key>captures</key>
+            <string>(\bthen\b)</string>
+            <key>beginCaptures</key>
             <dict>
               <key>0</key>
               <dict>
                 <key>name</key>
-                <string>keyword.control.teal</string>
+                <string>keyword.control.elseif.teal</string>
+              </dict>
+            </dict>
+            <key>endCaptures</key>
+            <dict>
+              <key>0</key>
+              <dict>
+                <key>name</key>
+                <string>keyword.control.then.teal</string>
               </dict>
             </dict>
             <key>name</key>
@@ -1247,10 +1311,18 @@
       <key>do-block</key>
       <dict>
         <key>begin</key>
-        <string>\bdo\b</string>
+        <string>(\bdo\b)</string>
         <key>end</key>
-        <string>\bend\b</string>
-        <key>captures</key>
+        <string>(\bend\b)</string>
+        <key>beginCaptures</key>
+        <dict>
+          <key>0</key>
+          <dict>
+            <key>name</key>
+            <string>keyword.control.teal</string>
+          </dict>
+        </dict>
+        <key>endCaptures</key>
         <dict>
           <key>0</key>
           <dict>
@@ -1271,10 +1343,18 @@
       <key>repeat-block</key>
       <dict>
         <key>begin</key>
-        <string>\brepeat\b</string>
+        <string>(\brepeat\b)</string>
         <key>end</key>
-        <string>\buntil\b</string>
-        <key>captures</key>
+        <string>(\buntil\b)</string>
+        <key>beginCaptures</key>
+        <dict>
+          <key>0</key>
+          <dict>
+            <key>name</key>
+            <string>keyword.control.teal</string>
+          </dict>
+        </dict>
+        <key>endCaptures</key>
         <dict>
           <key>0</key>
           <dict>
@@ -1295,10 +1375,18 @@
       <key>while-block</key>
       <dict>
         <key>begin</key>
-        <string>\bwhile\b</string>
+        <string>(\bwhile\b)</string>
         <key>end</key>
-        <string>\bend\b</string>
-        <key>captures</key>
+        <string>(\bend\b)</string>
+        <key>beginCaptures</key>
+        <dict>
+          <key>0</key>
+          <dict>
+            <key>name</key>
+            <string>keyword.control.teal</string>
+          </dict>
+        </dict>
+        <key>endCaptures</key>
         <dict>
           <key>0</key>
           <dict>
@@ -1353,10 +1441,18 @@
       <key>for-block</key>
       <dict>
         <key>begin</key>
-        <string>\bfor\b</string>
+        <string>(\bfor\b)</string>
         <key>end</key>
-        <string>\bend\b</string>
-        <key>captures</key>
+        <string>(\bend\b)</string>
+        <key>beginCaptures</key>
+        <dict>
+          <key>0</key>
+          <dict>
+            <key>name</key>
+            <string>keyword.control.teal</string>
+          </dict>
+        </dict>
+        <key>endCaptures</key>
         <dict>
           <key>0</key>
           <dict>


### PR DESCRIPTION
## Additions
- Optional in argument names
- Variable annotations `<const>`, `<close>` and `<total>`
- Interfaces (and extending interfaces/records with `is` and `where`)

## Changes
- More explicit capture groups for blocks (`function`, `record`, `enum`, `while`, `if`, `repeat`, `for`)
  - It seems as if Sublime Text (and maybe others?) requires more explicit capture groups to actually highlight the words correctly
- Slight change to `function-type` to usage to reuse `function-arg-name` and `function-arg-type`.
  - I wasn't _exactly_ sure why it wasn't reusing them before, so I hope it doesn't cause a regression. Can change back if needed.

## Pictures

Before:
![image](https://github.com/user-attachments/assets/f25ed439-8146-4f6d-a426-7dffc57d9cd4)

After:
![image](https://github.com/user-attachments/assets/a5138ee9-fdc7-4139-b32b-72494265f216)


Before:
![image](https://github.com/user-attachments/assets/e00a64fd-51c5-4ebf-932d-62cf50dd0cbd)

After:
![image](https://github.com/user-attachments/assets/e1ae3832-0751-47cf-978b-3857fbf8d6a7)

I'll maybe check VSCode to see if it has broken anything. 